### PR TITLE
Add expandable table view to Display

### DIFF
--- a/pages/Display.py
+++ b/pages/Display.py
@@ -1,17 +1,33 @@
 # pages/Display.py
 import streamlit as st
+import pandas as pd
 from db_utils import get_all_curriculums
 
 def show():
     st.header("Saved Curricula")
     data = get_all_curriculums()
-    if data:
-        for row in data:
-            st.markdown("---")
-            st.write(f"**ID:** {row[0]}")
-            st.write(f"**Topic Sentence:** {row[1]}")
-            st.write(f"**Topic:** {row[2]}")
-            st.write(f"**Prompt:** {row[3]}")
-            st.write(f"**Response:** {row[4]}")
-    else:
+    if not data:
         st.info("No curricula found.")
+        return
+
+    df = pd.DataFrame(data, columns=["ID", "Topic Sentence", "Topic", "Prompt", "Response"])
+    truncated_df = df.applymap(lambda x: str(x).splitlines()[0] if isinstance(x, str) else x)
+
+    table_html = "<table style='width:100%; border-collapse: collapse;'>"
+    # Header
+    table_html += "<thead><tr>" + "".join(f"<th style='border:1px solid #ddd;padding:8px'>{col}</th>" for col in truncated_df.columns) + "</tr></thead>"
+    table_html += "<tbody>"
+    for i, row in truncated_df.iterrows():
+        table_html += "<tr>"
+        for col in truncated_df.columns:
+            short = row[col]
+            full = df.loc[i, col]
+            cell_html = (
+                f"<details style='cursor:pointer'><summary>{short}</summary>"
+                f"<pre style='white-space:pre-wrap'>{full}</pre></details>"
+            )
+            table_html += f"<td style='border:1px solid #ddd;padding:8px;vertical-align:top'>{cell_html}</td>"
+        table_html += "</tr>"
+    table_html += "</tbody></table>"
+
+    st.markdown(table_html, unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- upgrade display page to show curricula in a table
- truncate cells to the first line and use HTML `<details>` for full text

## Testing
- `python -m py_compile pages/Display.py`
- `python -m py_compile app.py pages/Home.py pages/New_Curriculum.py db_utils.py llm_utils.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_687d8ea5425c833293ff036b541eb79e