### PR TITLE
Enhance New Curriculum input handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,5 +5,6 @@ from dotenv import load_dotenv
 load_dotenv()
 DEFAULT_PROMPT = "Generate a concise curriculum for the following topic."
 TOPIC_PROMPT = "Generate a topic name for the following sentence."
+DESCRIPTION_PROMPT = "Generate a short description for the following topic sentence."
 OPENAI_API_KEY = st.secrets.get('OPENAI_API_KEY', os.environ.get('OPENAI_API_KEY'))
 DB_FILE = "output/curriculum.db"

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -1,6 +1,6 @@
 # llm_utils.py
 import openai
-from config import OPENAI_API_KEY
+from config import OPENAI_API_KEY, DESCRIPTION_PROMPT
 
 client = openai.OpenAI(api_key=OPENAI_API_KEY)
 
@@ -20,6 +20,16 @@ def get_curriculum(topic, prompt):
         messages=[
             {"role": "system", "content": prompt},
             {"role": "user", "content": topic},
+        ]
+    )
+    return response.choices[0].message.content.strip()
+
+def get_topic_description(topic_sentence, prompt=DESCRIPTION_PROMPT):
+    response = client.chat.completions.create(
+        model="gpt-4.1-mini",
+        messages=[
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": topic_sentence},
         ]
     )
     return response.choices[0].message.content.strip()

--- a/pages/New_Curriculum.py
+++ b/pages/New_Curriculum.py
@@ -1,18 +1,48 @@
 # pages/New_Curriculum.py
 import streamlit as st
-from config import DEFAULT_PROMPT, TOPIC_PROMPT
+from config import DEFAULT_PROMPT, TOPIC_PROMPT, DESCRIPTION_PROMPT
 from db_utils import insert_curriculum
-from llm_utils import get_topic_name, get_curriculum
+from llm_utils import get_topic_name, get_curriculum, get_topic_description
 
 def show_new_curriculum():
     st.header("New Curriculum")
-    topic_sentence = st.text_input("Enter a topic sentence:")
+    topic_sentence = st.text_input("Topic Sentence (required):")
+    topic_name = st.text_input(
+        "Topic Name (optional):", value=st.session_state.get("topic_name", "")
+    )
+    topic_description = st.text_area(
+        "Topic Description (optional):",
+        value=st.session_state.get("topic_description", ""),
+    )
     prompt = st.text_area("Prompt for curriculum:", value=DEFAULT_PROMPT)
+
     if st.button("Generate Curriculum", disabled=not topic_sentence):
-        with st.spinner("Generating..."):
-            topic = get_topic_name(topic_sentence, TOPIC_PROMPT)
-            curriculum = get_curriculum(topic, prompt)
-            insert_curriculum(topic_sentence, topic, prompt, curriculum)
+        with st.spinner("Processing..."):
+            missing = False
+            if not topic_name:
+                topic_name = get_topic_name(topic_sentence, TOPIC_PROMPT)
+                st.session_state["topic_name"] = topic_name
+                missing = True
+            if not topic_description:
+                topic_description = get_topic_description(
+                    topic_sentence, DESCRIPTION_PROMPT
+                )
+                st.session_state["topic_description"] = topic_description
+                missing = True
+
+            if missing:
+                st.success(
+                    "Missing fields generated. Please review and press the button again to create the curriculum."
+                )
+                st.write(f"### Topic Name\n{topic_name}")
+                st.write(f"### Topic Description\n{topic_description}")
+                return
+
+            curriculum = get_curriculum(
+                f"{topic_name}\n\n{topic_description}", prompt
+            )
+            insert_curriculum(topic_sentence, topic_name, prompt, curriculum)
             st.success("Curriculum generated!")
-            st.write(f"### Topic Name\n{topic}")
+            st.write(f"### Topic Name\n{topic_name}")
+            st.write(f"### Topic Description\n{topic_description}")
             st.write(f"### Curriculum\n{curriculum}")


### PR DESCRIPTION
## Summary
- add DESCRIPTION_PROMPT constant to keep default prompt in config
- provide API helper for generating topic descriptions
- expand new curriculum page with optional name/description inputs
- auto generate missing name/description before creating curriculum

## Testing
- `python -m py_compile app.py config.py db_utils.py llm_utils.py pages/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687d914c2af48332a3af7377c906f93d