### PR TITLE
Implement upsert for curricula

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -22,12 +22,22 @@ def init_db():
             )
             """
         )
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_curriculum_topic ON curriculum(topic)"
+        )
         conn.commit()
 
 def insert_curriculum(topic_sentence, topic, prompt, response):
     with sqlite3.connect(DB_FILE) as conn:
         conn.execute(
-            "INSERT INTO curriculum (topic_sentence, topic, prompt, response) VALUES (?, ?, ?, ?)",
+            """
+            INSERT INTO curriculum (topic_sentence, topic, prompt, response)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(topic) DO UPDATE SET
+                topic_sentence=excluded.topic_sentence,
+                prompt=excluded.prompt,
+                response=excluded.response
+            """,
             (topic_sentence, topic, prompt, response)
         )
         conn.commit()


### PR DESCRIPTION
## Summary
- ensure `topic` values are unique by adding an index
- update `insert_curriculum` to upsert rows on topic conflicts

## Testing
- `python -m py_compile db_utils.py`
- `python - <<'PY'
import db_utils, sqlite3
print('init')
db_utils.init_db()
print('inserting first..')
db_utils.insert_curriculum('sent1','topic1','prompt1','response1')
print('inserting again with same topic..')
db_utils.insert_curriculum('sent2','topic1','prompt2','response2')
print('rows:')
conn=sqlite3.connect(db_utils.DB_FILE)
print(conn.execute('select topic_sentence,topic,prompt,response from curriculum').fetchall())
PY`

------
https://chatgpt.com/codex/tasks/task_e_687d95848c3c8332ae4d65d63f769faa