### PR TITLE
Add Modify Curriculum page

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from db_utils import init_db
 import pages.Home as Home
 import pages.New_Curriculum as New_Curriculum
 import pages.Display as Display
+import pages.Modify_Curriculum as Modify_Curriculum
 
 # Initialize database
 init_db()
@@ -15,6 +16,7 @@ page = st.navigation([
     st.Page(Home.show_home, title="Home", icon="🏠"),
     st.Page(New_Curriculum.show_new_curriculum, title="New Curriculum", icon="📝"),
     st.Page(Display.show_display, title="Display", icon="📄"),
+    st.Page(Modify_Curriculum.show_modify_curriculum, title="Modify Curriculum", icon="✏️"),
 ])
 
 page.run()

--- a/db_utils.py
+++ b/db_utils.py
@@ -48,3 +48,33 @@ def get_all_curriculums():
         columns = [desc[0] for desc in cur.description]
         rows = cur.fetchall()
         return columns, rows
+
+def get_all_topics():
+    with sqlite3.connect(DB_FILE) as conn:
+        cur = conn.execute("SELECT id, topic FROM curriculum ORDER BY topic")
+        return cur.fetchall()
+
+def get_curriculum_by_topic(topic):
+    with sqlite3.connect(DB_FILE) as conn:
+        cur = conn.execute("SELECT * FROM curriculum WHERE topic=?", (topic,))
+        row = cur.fetchone()
+        if not row:
+            return None
+        columns = [desc[0] for desc in cur.description]
+        return dict(zip(columns, row))
+
+def update_curriculum(curriculum_id, topic_sentence, topic, prompt):
+    with sqlite3.connect(DB_FILE) as conn:
+        conn.execute(
+            "UPDATE curriculum SET topic_sentence=?, topic=?, prompt=? WHERE id=?",
+            (topic_sentence, topic, prompt, curriculum_id),
+        )
+        conn.commit()
+
+def update_response(curriculum_id, response):
+    with sqlite3.connect(DB_FILE) as conn:
+        conn.execute(
+            "UPDATE curriculum SET response=? WHERE id=?",
+            (response, curriculum_id),
+        )
+        conn.commit()

--- a/pages/Modify_Curriculum.py
+++ b/pages/Modify_Curriculum.py
@@ -1,0 +1,47 @@
+# pages/Modify_Curriculum.py
+import streamlit as st
+from db_utils import (
+    get_all_topics,
+    get_curriculum_by_topic,
+    update_curriculum,
+    update_response,
+)
+from llm_utils import get_curriculum
+
+
+def show_modify_curriculum():
+    st.header("Modify Curriculum")
+
+    topics = [t[1] for t in get_all_topics()]
+    if not topics:
+        st.info("No curricula found.")
+        return
+
+    selected_topic = st.selectbox("Select Topic", topics)
+    data = get_curriculum_by_topic(selected_topic)
+    if not data:
+        st.error("Topic not found.")
+        return
+
+    topic_sentence = st.text_input("Topic Sentence", value=data["topic_sentence"])
+    topic = st.text_input("Topic", value=data["topic"])
+    prompt = st.text_area("Prompt", value=data["prompt"])
+    st.text_area("Response", value=data["response"], disabled=True, height=200)
+
+    col1, col2 = st.columns(2)
+    if col1.button("Save"):
+        update_curriculum(data["id"], topic_sentence, topic, prompt)
+        st.success("Saved")
+    if col2.button("Generate"):
+        with st.spinner("Generating..."):
+            response = get_curriculum(f"{topic_sentence}", prompt)
+            update_response(data["id"], response)
+            st.session_state["generated_response"] = response
+            st.success("Response updated")
+            st.text_area(
+                "Response",
+                value=response,
+                disabled=True,
+                height=200,
+                key="updated_response",
+            )


### PR DESCRIPTION
## Summary
- add new Streamlit page to modify existing curriculum records
- extend DB utilities with helpers to update and query curricula
- hook new page into app navigation

## Testing
- `pip install -r requirements.txt`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687d9cf1a0a083329a9523bf71abb2e9